### PR TITLE
feat: add ErrorBox styling and logic to frontend

### DIFF
--- a/sh24-client/src/App.css
+++ b/sh24-client/src/App.css
@@ -8,12 +8,16 @@
   color: black;
 }
 
-body {
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   height: 100%;
   width: 100%;
 }
 
-main {
-  width: 100%;
-  height: 100%;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }

--- a/sh24-client/src/App.tsx
+++ b/sh24-client/src/App.tsx
@@ -2,14 +2,18 @@ import { useState } from "react";
 import "./App.css";
 import ErrorBox from "./components/ErrorBox/ErrorBox";
 import PostcodeInput from "./components/PostcodeInput/PostcodeInput";
+import type { RequestError } from "./types/requests";
 
 function App() {
-  const [errorMesage, setErrorMessage] = useState<string | null>(null);
+  const [errorMesage, setErrorMessage] = useState<RequestError | null>(null);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     console.log("Form submitted");
-    setErrorMessage("This is an error message");
+    setErrorMessage({
+      isSuccess: false,
+      error: { type: "input", message: "Invalid postcode" },
+    });
   };
   return (
     <main>

--- a/sh24-client/src/components/ErrorBox/ErrorBox.css
+++ b/sh24-client/src/components/ErrorBox/ErrorBox.css
@@ -1,0 +1,23 @@
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+  gap: 0.5rem;
+  background-color: rgb(250, 177, 177);
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+}
+
+.error__heading {
+  font-size: clamp(1rem, 2vw, 1.5rem);
+  font-weight: 500;
+  margin: 0;
+}
+
+.error_message {
+  font-size: clamp(0.75rem, 1vw, 1rem);
+  margin: 0;
+}

--- a/sh24-client/src/components/ErrorBox/ErrorBox.tsx
+++ b/sh24-client/src/components/ErrorBox/ErrorBox.tsx
@@ -6,5 +6,12 @@ export default function ErrorBox({
 }: {
   errorMessage: RequestError | null;
 }) {
-  return <p>{errorMessage?.error.message}</p>;
+  return (
+    errorMessage && (
+      <section className='error'>
+        <h2 className='error__heading'>Error</h2>
+        <p className='error_message'>{errorMessage?.error.message}</p>
+      </section>
+    )
+  );
 }

--- a/sh24-client/src/components/ErrorBox/ErrorBox.tsx
+++ b/sh24-client/src/components/ErrorBox/ErrorBox.tsx
@@ -1,9 +1,10 @@
+import type { RequestError } from "../../types/requests";
 import "./ErrorBox.css";
 
 export default function ErrorBox({
   errorMessage,
 }: {
-  errorMessage: string | null;
+  errorMessage: RequestError | null;
 }) {
-  return <p>{errorMessage}</p>;
+  return <p>{errorMessage?.error.message}</p>;
 }

--- a/sh24-client/src/components/PostcodeInput/PostcodeInput.css
+++ b/sh24-client/src/components/PostcodeInput/PostcodeInput.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
   max-width: 360px;
   margin: 0 auto;
 }

--- a/sh24-client/src/types/error.ts
+++ b/sh24-client/src/types/error.ts
@@ -1,0 +1,6 @@
+export type ErrorTypes = "input" | "network" | "server" | "zod";
+export type ErrorMessages = {
+  type: ErrorTypes;
+  message: string;
+  statusCode?: number;
+};

--- a/sh24-client/src/types/requests.ts
+++ b/sh24-client/src/types/requests.ts
@@ -1,0 +1,18 @@
+import type { ErrorMessages } from "./Error";
+import type { SuccessMessage } from "./Success";
+
+export interface RequestResponseBase {
+  isSuccess: boolean;
+}
+
+export interface RequestError extends RequestResponseBase {
+  isSuccess: false;
+  error: ErrorMessages;
+}
+
+export interface RequestSuccess extends RequestResponseBase {
+  isSuccess: false;
+  success: SuccessMessage;
+}
+
+export type RequestResponse = RequestError | RequestSuccess;

--- a/sh24-client/src/types/success.ts
+++ b/sh24-client/src/types/success.ts
@@ -1,0 +1,4 @@
+export type SuccessMessage = {
+  message: string;
+  statusCode?: number;
+};


### PR DESCRIPTION
## What did I do?

I added types for catching request Success Messages and Error Messages and wired them up into the ErrorBox component logic. It will display the `<ErrorBox />` when an error comes in and it will be hidden when not there.  

Work still to be done on capturing the input error validation and the like. I'll add this in subsequent PRs.

# Key feature

Types to capture successes and errors, and the `ErrorBox` component responding to this.