### PR TITLE
feat: add base route for sending postcode

### DIFF
--- a/sh24-server/eslint.config.js
+++ b/sh24-server/eslint.config.js
@@ -19,17 +19,13 @@ export default tseslint.config(
       ecmaVersion: 2022,
       sourceType: "module",
       globals: {
-        ...compat.config.globals.node,
+        ...compat.env(),
       },
       parserOptions: {
         project: "./tsconfig.json",
         ecmaVersion: 2022,
         sourceType: "module",
       },
-    },
-    env: {
-      node: true,
-      es2022: true,
     },
     rules: {
       // Node.js specific rules
@@ -54,7 +50,7 @@ export default tseslint.config(
         "error",
         {
           selector: "variable",
-          format: ["camelCase"],
+          format: ["camelCase", "UPPER_CASE"],
         },
         {
           selector: "function",

--- a/sh24-server/eslint.config.js
+++ b/sh24-server/eslint.config.js
@@ -21,8 +21,8 @@ export default tseslint.config(
       globals: {
         ...compat.env(),
       },
+      // parserOptions.project is omitted here to avoid type-aware linting on config files
       parserOptions: {
-        project: "./tsconfig.json",
         ecmaVersion: 2022,
         sourceType: "module",
       },
@@ -68,15 +68,12 @@ export default tseslint.config(
 
   // Apply overrides for specific file patterns
   {
-    files: ["**/*.ts"],
-    rules: {
-      // TypeScript file specific rules
-    },
+    files: ["src/*.ts"],
   },
 
   // Special configuration for test files (if any)
   {
-    files: ["**/*.test.ts", "**/*.spec.ts"],
+    files: ["src/*.test.ts"],
     rules: {
       // Test file specific rules
       "no-console": "off",

--- a/sh24-server/package.json
+++ b/sh24-server/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "start": "tsx src/index.ts"
+    "start": "tsx watch src/index.ts"
   },
   "keywords": [],
   "author": "",

--- a/sh24-server/package.json
+++ b/sh24-server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
@@ -25,7 +26,8 @@
     "supertest": "^7.1.1",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.32.1"
+    "typescript-eslint": "^8.32.1",
+    "globals": "^16.0.0"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/sh24-server/pnpm-lock.yaml
+++ b/sh24-server/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       eslint:
         specifier: ^9.27.0
         version: 9.27.0
+      globals:
+        specifier: ^16.0.0
+        version: 16.1.0
       msw:
         specifier: ^2.8.4
         version: 2.8.4(@types/node@22.15.21)(typescript@5.8.3)
@@ -1249,6 +1252,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.1.0:
+    resolution: {integrity: sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==}
     engines: {node: '>=18'}
 
   gopd@1.2.0:
@@ -3530,6 +3537,8 @@ snapshots:
   globals@11.12.0: {}
 
   globals@14.0.0: {}
+
+  globals@16.1.0: {}
 
   gopd@1.2.0: {}
 

--- a/sh24-server/src/index.ts
+++ b/sh24-server/src/index.ts
@@ -28,7 +28,7 @@ app.get("/postcode/:postcode", async (req, res) => {
     if (!response.ok) {
       res.status(404).json({ error: "Postcode not found" });
     }
-    const data = await response.json();
+    const data = response.json();
     res.status(200).json(data);
   } catch (error) {
     console.error("Error fetching postcode data:", error);
@@ -36,11 +36,6 @@ app.get("/postcode/:postcode", async (req, res) => {
   }
 });
 
-app
-  .listen(PORT, () => {
-    console.log(`Server running in ${NODE_ENV} mode on port ${PORT}`);
-  })
-  .on("error", (err) => {
-    console.error("Error starting server:", err);
-    process.exit(1);
-  });
+app.listen(PORT, () => {
+  console.log(`Server running in ${NODE_ENV} mode on port ${PORT}`);
+});

--- a/sh24-server/src/index.ts
+++ b/sh24-server/src/index.ts
@@ -1,18 +1,41 @@
 import { config } from "dotenv";
 import express from "express";
 import cors from "cors";
+import { z } from "zod/v4";
 
 // Load environment variables
 config();
 
 const PORT = process.env.PORT || 8080;
 const NODE_ENV = process.env.NODE_ENV || "development";
+const postcodeIoUrl = "https://api.postcodes.io/postcodes";
 
 const app = express();
 
 app.use(cors());
-app.use(express.json({ limit: "10mb" }));
-app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+
+app.get("/postcode/:postcode", async (req, res) => {
+  const { postcode } = req.params;
+  const validatedPostcode = z.string().min(5).max(7).safeParse(postcode);
+
+  if (!validatedPostcode.success) {
+    res.status(400).send({
+      error: `'${postcode}' is in an invalid format. Enter a postcode similar to SW12 4AB`,
+    });
+  }
+
+  try {
+    const response = await fetch(`${postcodeIoUrl}/${postcode}`);
+    if (!response.ok) {
+      res.status(404).json({ error: "Postcode not found" });
+    }
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching postcode data:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
 
 app.get("/health", (_req, res) => {
   res.status(200).json({

--- a/sh24-server/src/index.ts
+++ b/sh24-server/src/index.ts
@@ -3,7 +3,6 @@ import express from "express";
 import cors from "cors";
 import { z } from "zod/v4";
 
-// Load environment variables
 config();
 
 const PORT = process.env.PORT || 8080;
@@ -35,14 +34,6 @@ app.get("/postcode/:postcode", async (req, res) => {
     console.error("Error fetching postcode data:", error);
     res.status(500).json({ error: "Internal server error" });
   }
-});
-
-app.get("/health", (_req, res) => {
-  res.status(200).json({
-    status: "healthy",
-    timestamp: new Date().toISOString(),
-    environment: NODE_ENV,
-  });
 });
 
 app


### PR DESCRIPTION
# What does this PR do?

I have added the initial base `get` route for checking whether a postcode exists. I have also added in zod schema validation to check string, only on length so far. 

This will need to be expanded upon once I get tests up and running.

## Key Feature

A `GET` route in the backend for receiving a postcode, validating it, checking it with postcodes.io, and sending a response back to the requester.

All functional changes are in `index.ts` 