### PR TITLE
feat: backend integration tests

### DIFF
--- a/sh24-server/src/__tests__/mocks/handlers.ts
+++ b/sh24-server/src/__tests__/mocks/handlers.ts
@@ -2,12 +2,46 @@ import { http, HttpResponse } from "msw";
 import { postcodeIoUrl } from "../../index.js";
 import { southwarkAPIResponse, southwarkPostcode } from "./southwark.js";
 import { lambethAPIResponse, lambethPostcode } from "./lambeth.js";
+import {
+  invalidAPIResponse,
+  invalidPostcode,
+  invalidServiceAreaAPIResponse,
+  invalidServiceAreaPostcode,
+} from "./invalidData.js";
+import { transfromAndSantitisePostcode } from "../../controllers/utils/transformations.js";
+import { firstSHPostcode } from "./sh24.js";
 
 export const handlers = [
-  http.get(`${postcodeIoUrl}/${southwarkPostcode}`, () => {
-    return HttpResponse.json(southwarkAPIResponse);
-  }),
-  http.get(`${postcodeIoUrl}/${lambethPostcode}`, () => {
-    return HttpResponse.json(lambethAPIResponse);
-  }),
+  http.get(
+    `${postcodeIoUrl}/${transfromAndSantitisePostcode(southwarkPostcode)}`,
+    () => {
+      return HttpResponse.json(southwarkAPIResponse, { status: 200 });
+    }
+  ),
+  http.get(
+    `${postcodeIoUrl}/${transfromAndSantitisePostcode(lambethPostcode)}`,
+    () => {
+      return HttpResponse.json(lambethAPIResponse, { status: 200 });
+    }
+  ),
+  http.get(
+    `${postcodeIoUrl}/${transfromAndSantitisePostcode(firstSHPostcode)}`,
+    () => {
+      return HttpResponse.json({ status: 200, ok: true }, { status: 200 });
+    }
+  ),
+  http.get(
+    `${postcodeIoUrl}/${transfromAndSantitisePostcode(invalidPostcode)}`,
+    () => {
+      return HttpResponse.json(invalidAPIResponse, { status: 404 });
+    }
+  ),
+  http.get(
+    `${postcodeIoUrl}/${transfromAndSantitisePostcode(
+      invalidServiceAreaPostcode
+    )}`,
+    () => {
+      return HttpResponse.json(invalidServiceAreaAPIResponse);
+    }
+  ),
 ];

--- a/sh24-server/src/__tests__/mocks/invalidData.ts
+++ b/sh24-server/src/__tests__/mocks/invalidData.ts
@@ -1,0 +1,17 @@
+export const invalidZodPostcode = "INV125BGO";
+export const invalidPostcode = "xx122nn";
+export const invalidServiceAreaPostcode = "e26pp";
+export const invalidServiceArea = "Cambuslang 000";
+
+export const invalidAPIResponse = {
+  error: "Postcode not found",
+};
+
+export const invalidServiceAreaAPIResponse = {
+  status: 200,
+  ok: true,
+  result: {
+    postcode: invalidServiceAreaPostcode,
+    lsoa: "Tower Hamlets 036B",
+  },
+};

--- a/sh24-server/src/__tests__/mocks/lambeth.ts
+++ b/sh24-server/src/__tests__/mocks/lambeth.ts
@@ -1,7 +1,8 @@
-export const lambethPostcode = "SE1 7QA";
+export const lambethPostcode = "SE17QA";
 
 export const lambethAPIResponse = {
   status: 200,
+  ok: true,
   result: {
     postcode: "SE1 7QA",
     lsoa: "Lambeth 036B",

--- a/sh24-server/src/__tests__/mocks/southwark.ts
+++ b/sh24-server/src/__tests__/mocks/southwark.ts
@@ -1,7 +1,8 @@
-export const southwarkPostcode = "SE1 7QD";
+export const southwarkPostcode = "SE17QD";
 
 export const southwarkAPIResponse = {
   status: 200,
+  ok: true,
   result: {
     postcode: "SE1 7QD",
     lsoa: "Southwark 034A",

--- a/sh24-server/src/app.ts
+++ b/sh24-server/src/app.ts
@@ -1,0 +1,10 @@
+import express, { Express } from "express";
+import cors from "cors";
+import { postcodeRoutes } from "./routes/postcode.js";
+
+export const postcodeIoUrl = "https://api.postcodes.io/postcodes";
+
+export const app: Express = express();
+
+app.use(cors());
+app.use("/postcode", postcodeRoutes);

--- a/sh24-server/src/controllers/postcode.integration.test.ts
+++ b/sh24-server/src/controllers/postcode.integration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import request from "supertest";
+import { server } from "../__tests__/mocks/server.js";
+import { southwarkPostcode } from "../__tests__/mocks/southwark.js";
+import { lambethPostcode } from "../__tests__/mocks/lambeth.js";
+import { firstSHPostcode } from "../__tests__/mocks/sh24.js";
+import { app } from "../app.js";
+import {
+  invalidPostcode,
+  invalidServiceAreaPostcode,
+  invalidZodPostcode,
+} from "../__tests__/mocks/invalidData.js";
+
+describe("Postcode Integration Tests", () => {
+  before(() => {
+    server.listen();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  describe("requests for valid postcodes", () => {
+    it("should return success for allowed SH24 postcodes", async () => {
+      const response = await request(app)
+        .get(`/postcode/${firstSHPostcode}`)
+        .expect(200);
+      assert.strictEqual(response.body.isSuccess, true);
+      assert(response.body.data.message.includes("valid postcode"));
+    });
+
+    it("should return success for Southwark postcodes", async () => {
+      const response = await request(app)
+        .get(`/postcode/${southwarkPostcode}`)
+        .expect(200);
+
+      assert.strictEqual(response.body.isSuccess, true);
+      assert(response.body.data.message.includes("service area"));
+    });
+
+    it("should return success for Lambeth postcodes", async () => {
+      const response = await request(app)
+        .get(`/postcode/${lambethPostcode}`)
+        .expect(200);
+
+      assert.strictEqual(response.body.isSuccess, true);
+      assert(response.body.data.message.includes("service area"));
+    });
+  });
+
+  describe("requests for invalid postcodes or service areas", () => {
+    it("should return 400 for invalid postcode format", async () => {
+      const response = await request(app)
+        .get(`/postcode/${invalidZodPostcode}`)
+        .expect(400);
+
+      assert.strictEqual(response.body.isSuccess, false);
+      assert.strictEqual(response.body.error.type, "zod");
+    });
+
+    it("should return error for postcodes it can't find", async () => {
+      const response = await request(app)
+        .get(`/postcode/${invalidPostcode}`)
+        .expect(404);
+
+      assert.strictEqual(response.body.error, "Postcode not found");
+    });
+
+    it("should return error for postcodes in disallowed service areas", async () => {
+      const response = await request(app)
+        .get(`/postcode/${invalidServiceAreaPostcode}`)
+        .expect(400);
+
+      assert.strictEqual(response.body.isSuccess, false);
+      assert.strictEqual(
+        response.body.error.message,
+        `'${invalidServiceAreaPostcode}' is in Tower Hamlets which is not an allowed service area. Enter another postcode`
+      );
+    });
+  });
+});

--- a/sh24-server/src/controllers/postcode.validation.test.ts
+++ b/sh24-server/src/controllers/postcode.validation.test.ts
@@ -9,10 +9,11 @@ import {
 import { southwarkPostcode } from "../__tests__/mocks/southwark.js";
 import { firstSHPostcode } from "../__tests__/mocks/sh24.js";
 import { lambethPostcode } from "../__tests__/mocks/lambeth.js";
-
-const invalidZodPostcode = "INV12 5BGO";
-const invalidPostcode = "xx122nn";
-const invalidServiceArea = "Cambuslang 000";
+import {
+  invalidPostcode,
+  invalidServiceArea,
+  invalidZodPostcode,
+} from "../__tests__/mocks/invalidData.js";
 
 describe("zod postcode validation", () => {
   it("creates a zod error for invalid postcodes", () => {

--- a/sh24-server/src/controllers/utils/transformations.ts
+++ b/sh24-server/src/controllers/utils/transformations.ts
@@ -1,5 +1,7 @@
 export const transfromAndSantitisePostcode = (postcode: string) => {
   const lowercasePostcode = postcode.toLowerCase();
-  const sanitizedPostcode = lowercasePostcode.replace(" ", "");
+  const sanitizedPostcode = lowercasePostcode
+    .replace(" ", "")
+    .replace("%20", "");
   return sanitizedPostcode;
 };

--- a/sh24-server/src/controllers/utils/validation.ts
+++ b/sh24-server/src/controllers/utils/validation.ts
@@ -13,7 +13,7 @@ export const checkIfPostcodeIsAllowed = (postcode: string) =>
   POSTCODE_ALLOW_LIST.find((allowedPostcode) => allowedPostcode === postcode);
 
 export function checkIfAllowedServiceArea(lsoa: string, postcode: string) {
-  const [serviceArea] = lsoa.split(" ");
+  const serviceArea = lsoa.split(" ").slice(0, -1).join(" ");
   const isAllowedServiceArea = checkIfPostcodeIsInLsoa(serviceArea);
 
   if (!isAllowedServiceArea) {

--- a/sh24-server/src/index.ts
+++ b/sh24-server/src/index.ts
@@ -1,18 +1,11 @@
 import { config } from "dotenv";
-import express from "express";
-import cors from "cors";
-import { postcodeRoutes } from "./routes/postcode.js";
+import { app } from "./app.js";
 
 config();
 
 const PORT = process.env.PORT || 8080;
 const NODE_ENV = process.env.NODE_ENV || "development";
 export const postcodeIoUrl = "https://api.postcodes.io/postcodes";
-
-const app = express();
-
-app.use(cors());
-app.use("/postcode", postcodeRoutes);
 
 app.listen(PORT, () => {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
This pull request introduces significant enhancements to the SH24 server by restructuring the application, improving postcode validation, and expanding test coverage. Key changes include the modularization of the application setup, refined postcode handling logic, and the addition of integration tests for various postcode scenarios.

### Application Restructuring:
* Extracted the Express app initialization to a new `app.ts` file for better modularity and reusability. This includes setting up CORS and routing for `/postcode` (`sh24-server/src/app.ts`).
* Updated the `index.ts` file to use the new `app` module, simplifying the server initialization (`sh24-server/src/index.ts`).

### Postcode Handling Improvements:
* Enhanced the `transfromAndSantitisePostcode` utility to handle additional cases, such as replacing `%20` with an empty string (`sh24-server/src/controllers/utils/transformations.ts`).
* Refined the `checkPostcode` controller to improve error handling, ensure proper response codes, and handle edge cases more gracefully (`sh24-server/src/controllers/postcode.ts`). [[1]](diffhunk://#diff-a3ef20b3287c0e67407c8507ec58ee7573762f6ee947d6718da5a36cabcbaf7dL15-R18) [[2]](diffhunk://#diff-a3ef20b3287c0e67407c8507ec58ee7573762f6ee947d6718da5a36cabcbaf7dR29-L54)
* Adjusted the logic for determining allowed service areas by modifying the `checkIfAllowedServiceArea` function to handle multi-word service area names (`sh24-server/src/controllers/utils/validation.ts`).

### Expanded Test Coverage:
* Added integration tests for postcode validation, including tests for valid postcodes, invalid formats, and disallowed service areas (`sh24-server/src/controllers/postcode.integration.test.ts`).
* Updated mock data to include invalid postcodes and service areas, along with their expected API responses, to support comprehensive test cases (`sh24-server/src/__tests__/mocks/invalidData.ts`).
* Adjusted existing mock data for Southwark and Lambeth postcodes to include an `ok` field in responses (`sh24-server/src/__tests__/mocks/southwark.ts`, `sh24-server/src/__tests__/mocks/lambeth.ts`). [[1]](diffhunk://#diff-82f53eef8bd48416eace06fed1df2c16fdebb36af5e1311f68ffa2467ea5790dR5) [[2]](diffhunk://#diff-62c8a840598683e28d9a40d6ef4eaf62d8c972c5621b56277fc8f57a4f1d62f9R5)

### Mock Handlers Updates:
* Updated mock handlers to use the `transfromAndSantitisePostcode` utility and added new handlers for invalid postcodes and service areas (`sh24-server/src/__tests__/mocks/handlers.ts`).