### PR TITLE
Rory/backend refactor

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -2,6 +2,10 @@
 
 ## Global
 
+Trying my best to capture thoughts and decisions while keeping PRs and commits small so it's easier as I come back and forth.
+
+Main aim is to hit the challenge and make note of refactors, and come back if I still have time in the 4 hours.
+
 ## Where do I put the allow list?
 
 Thinking about this now, I'd rather have one set of Allow Lists, one for postcodes and one for LSOAs. I'm trying to think how they connect together and if they should relate to each other and thus be one allow list, but I'm not that deep in it. Current call seems simplest.
@@ -18,6 +22,8 @@ Unit tests were simple, mostly does it render and does it do something
 
 For hooking up with the backend, I've tried to keep it simple with the error journey and success journey both delivering a `data` field to the `handleSubmit` which feeds either state variable for `errorMessage` and `successMessage` which then controls which message gets displayed.
 
+Something missing that I thought of was a `loading` state. Definitely a good thing to put in considering I rely on an external API.
+
 ## Backend
 
 Built this with routes and controllers as it separated out nicely what done the logic within a route, and what done the logic outside of the route. This decoupling also relates to potential additions in future, hopefully this helps. It could have sent in a module or service structure, but it goes along with my thinking in this structure.
@@ -33,3 +39,5 @@ Most decisions went toward decoupling logic and keeping files small. The `contro
 Decided to add in base test cases for e2e to make sure the journeys are all covered and isolated.
 
 Built this so it could run from the root and call upon tests in an e2e folder. This was just my first instinct since it could run each part of the stack then the tests.
+
+Hit a bit of overlap with integrations, but smoothed it out by reducing the scope, focusing on hitting user journeys.

--- a/decisions.md
+++ b/decisions.md
@@ -26,7 +26,7 @@ Tests are built first focusing on the functions that dictate the controller func
 
 Allow List files ended up in a `logic/` folder as I couldn't at first thinking get a better name, but there's probably one.
 
-Most decisions went toward decoupling logic and keeping files small.
+Most decisions went toward decoupling logic and keeping files small. The `controller/postcode.ts` file flies in the face of this a bit as I ran out of time to break it down into something more manageable.
 
 ## E2E
 

--- a/sh24-server/package.json
+++ b/sh24-server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "tsx --watch --test src/controllers/postcode.*.test.ts",
+    "test": "tsx --watch --test src/__tests__/*/*.test.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "start": "tsx watch src/index.ts"

--- a/sh24-server/package.json
+++ b/sh24-server/package.json
@@ -31,6 +31,7 @@
     "typescript-eslint": "^8.32.1"
   },
   "dependencies": {
+    "axios": "^1.9.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",

--- a/sh24-server/pnpm-lock.yaml
+++ b/sh24-server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      axios:
+        specifier: ^1.9.0
+        version: 1.9.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -542,6 +545,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -811,6 +817,15 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
@@ -1153,6 +1168,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -1858,6 +1876,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axios@1.9.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   balanced-match@1.0.2: {}
 
   body-parser@2.2.0:
@@ -2195,6 +2221,8 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.9: {}
+
   form-data@4.0.2:
     dependencies:
       asynckit: 0.4.0
@@ -2513,6 +2541,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
     dependencies:

--- a/sh24-server/src/controllers/postcode.ts
+++ b/sh24-server/src/controllers/postcode.ts
@@ -1,18 +1,19 @@
 import { postcodeIoUrl } from "../index.js";
-import { RequestResponse } from "../types/requests.js";
+import { PostcodeIOResponse, RequestResponse } from "../types/requests.js";
 import { RequestHandler } from "express";
 import {
   checkAndValidatePostcode,
   checkIfAllowedServiceArea,
   checkIfPostcodeIsAllowed,
 } from "./utils/validation.js";
+import axios from "axios";
 
 export const checkPostcode: RequestHandler = async (req, res) => {
   const { postcode } = req.params;
 
   const validatedPostcode = checkAndValidatePostcode(postcode);
 
-  if (typeof validatedPostcode !== "string" && validatedPostcode.error) {
+  if (typeof validatedPostcode !== "string") {
     res.status(400).json(validatedPostcode);
     return;
   }
@@ -29,14 +30,9 @@ export const checkPostcode: RequestHandler = async (req, res) => {
     return;
   }
   try {
-    const response = await fetch(
-      `${postcodeIoUrl}/${validatedPostcode as string}`
-    );
-
-    const data = (await response.json()) as {
-      status: number;
-      result: { lsoa: string };
-    };
+    const { data } = (await axios.get(
+      `${postcodeIoUrl}/${validatedPostcode}`
+    )) satisfies PostcodeIOResponse;
 
     if (data.status === 404) {
       const errorResponse: RequestResponse = {

--- a/sh24-server/src/types/requests.ts
+++ b/sh24-server/src/types/requests.ts
@@ -16,3 +16,10 @@ export interface RequestSuccess extends RequestResponseBase {
 }
 
 export type RequestResponse = RequestError | RequestSuccess;
+
+export interface PostcodeIOResponse {
+  data: {
+    status: number;
+    result: { lsoa: string };
+  };
+}


### PR DESCRIPTION
This pull request introduces several changes aimed at improving the backend logic, enhancing error handling, and updating dependencies. The most significant updates include refactoring the `checkPostcode` controller to use `axios` for API calls, adding a new interface for API responses, and updating the testing and dependency configurations.

### Backend Improvements:
* Refactored the `checkPostcode` controller in `sh24-server/src/controllers/postcode.ts` to replace the `fetch` API with `axios` for making API calls. This includes improved error handling for `404` responses and other API errors using `AxiosError`. [[1]](diffhunk://#diff-a3ef20b3287c0e67407c8507ec58ee7573762f6ee947d6718da5a36cabcbaf7dL2-R22) [[2]](diffhunk://#diff-a3ef20b3287c0e67407c8507ec58ee7573762f6ee947d6718da5a36cabcbaf7dL32-R40) [[3]](diffhunk://#diff-a3ef20b3287c0e67407c8507ec58ee7573762f6ee947d6718da5a36cabcbaf7dL75-R81)
* Added a new `PostcodeIOResponse` interface in `sh24-server/src/types/requests.ts` to strongly type the API response from Postcode.io.

### Dependency Updates:
* Added `axios` as a new dependency in `sh24-server/package.json` and `sh24-server/pnpm-lock.yaml` to facilitate API requests. [[1]](diffhunk://#diff-35e59160eda60eb1b76256c5341285b247ea005501f3ddff8a6e61a021cb4a4cR34) [[2]](diffhunk://#diff-94a8d05a71dfe8c6dbd47b4acd6088ada0a8db9764baf4568dca4374dda7593eR11-R13) [[3]](diffhunk://#diff-94a8d05a71dfe8c6dbd47b4acd6088ada0a8db9764baf4568dca4374dda7593eR548-R550) [[4]](diffhunk://#diff-94a8d05a71dfe8c6dbd47b4acd6088ada0a8db9764baf4568dca4374dda7593eR1879-R1886)

### Testing Configuration:
* Updated the `test` script in `sh24-server/package.json` to include all test files under the `src/__tests__/` directory, ensuring broader test coverage.

### Documentation Updates:
* Added notes in `decisions.md` about the importance of implementing a `loading` state and the challenges faced in decoupling logic, particularly in the `controller/postcode.ts` file. [[1]](diffhunk://#diff-80a4cf760a0fa2bff988c75b611448073519d9f9b9cbbde4410f8846097c7a7aR5-R8) [[2]](diffhunk://#diff-80a4cf760a0fa2bff988c75b611448073519d9f9b9cbbde4410f8846097c7a7aR25-R26) [[3]](diffhunk://#diff-80a4cf760a0fa2bff988c75b611448073519d9f9b9cbbde4410f8846097c7a7aL29-R43)